### PR TITLE
Command expects an int, pack it as such

### DIFF
--- a/src/epc/tofCam660/command.py
+++ b/src/epc/tofCam660/command.py
@@ -178,7 +178,7 @@ class SetFlexModFrequency(Command):
     commandId = 52
 
     def dataToBytes(self):
-        return struct.pack('!f', self.data)
+        return struct.pack('!L', self.data)
 
 
 class GetTemperature(Command):


### PR DESCRIPTION
SetFlexModFrequency expects an int, not a float

![float](https://media.tenor.com/japdG6mkn94AAAAM/twiggy-squirrel.gif)