### PR TITLE
Fix a typo in the flexible frequency command

### DIFF
--- a/src/epc/tofCam660/tofCam660.py
+++ b/src/epc/tofCam660/tofCam660.py
@@ -222,7 +222,7 @@ class TOFcam660_Settings(TOF_Settings_Controller):
         log.info(f"Setting lense type: {lense_type}")
         self.lense_projection = Lense_Projection.from_lense_calibration(lense_type)
 
-    def set_flex_mod_frequences(self, frequency):
+    def set_flex_mod_frequency(self, frequency):
         """Set the flexible modulation frequency"""
         log.info(f'Setting flexible modulation frequency to {frequency}')
         flex_mod_command = Command.create("setFlexModFrequency", frequency)


### PR DESCRIPTION
Rename to set_flex_mod_frequency since we're setting 1 frequency

Safe to update since this method is only used by experiment code (i.e. only manually run by me)