### PR TITLE
Add an explicit close so we don't need to rely on destructors

### DIFF
--- a/src/epc/tofCam660/tofCam660.py
+++ b/src/epc/tofCam660/tofCam660.py
@@ -351,10 +351,6 @@ class TOFcam660(TOFcam):
         self.tcpInterface.close()
         self.udpInterface.close()
 
-
-    def __del__(self):
-        self.close()
-
     def __get_image_date(self, command: Command):
         self.tcpInterface.transceive(command)
         try:

--- a/src/epc/tofCam660/tofCam660.py
+++ b/src/epc/tofCam660/tofCam660.py
@@ -347,9 +347,13 @@ class TOFcam660(TOFcam):
         super().__init__(self.settings, self.device)
         self.memory = Memory.create(0)
 
-    def __del__(self):
+    def close(self):
         self.tcpInterface.close()
         self.udpInterface.close()
+
+
+    def __del__(self):
+        self.close()
 
     def __get_image_date(self, command: Command):
         self.tcpInterface.transceive(command)


### PR DESCRIPTION
Add an explicit close so we don't need to rely on destructors

![close](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXcxazg0cG05cW1iM2c4OGpxYW44ZXM0cTNibzlvaWlhOWsxdGZmYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/d2ZeJSRDqd8P4RIQ/200.webp)